### PR TITLE
Add SMTP configuration needed for password recovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:jessie
 
-ENV FUSIONDIRECTORY_DEB_PKG_VERSION=1.0.9.1-1 \
+ENV FUSIONDIRECTORY_DEB_PKG_VERSION=1.0.9.3-1 \
     LDAP_DOMAIN=fovea.cc \
     LDAP_PASSWORD=changeme \
     FUSIONDIRECTORY_PASSWORD=changeme2
@@ -13,7 +13,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get install -y software-properties-common gnupg && \
     gpg --keyserver keys.gnupg.net --recv-keys E184859262B4981F && \
     gpg -a --export E184859262B4981F | apt-key add - && \
-    add-apt-repository 'deb http://repos.fusiondirectory.org/debian-jessie jessie main' && \
+    add-apt-repository 'deb http://repos.fusiondirectory.org/official-releases/debian/fusiondirectory-109-jessie jessie main' && \
     apt-get update && \
     apt-get install -y php-mdb2 \
         fusiondirectory=${FUSIONDIRECTORY_DEB_PKG_VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ FROM debian:jessie
 ENV FUSIONDIRECTORY_DEB_PKG_VERSION=1.0.9.3-1 \
     LDAP_DOMAIN=fovea.cc \
     LDAP_PASSWORD=changeme \
-    FUSIONDIRECTORY_PASSWORD=changeme2
+    FUSIONDIRECTORY_PASSWORD=changeme2 \
+    SMTP_HOST=smtp \
+    SMTP_PORT=25 \
+    SMTP_TLSCERTCHECK=off
 
 EXPOSE 80
 
@@ -15,13 +18,14 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     gpg -a --export E184859262B4981F | apt-key add - && \
     add-apt-repository 'deb http://repos.fusiondirectory.org/official-releases/debian/fusiondirectory-109-jessie jessie main' && \
     apt-get update && \
-    apt-get install -y php-mdb2 \
+    apt-get install -y php-mdb2 msmtp \
         fusiondirectory=${FUSIONDIRECTORY_DEB_PKG_VERSION} \
         fusiondirectory-plugin-mail=${FUSIONDIRECTORY_DEB_PKG_VERSION} && \
     rm -rf /var/lib/apt/lists/*
 
 COPY apache.conf /etc/apache2/sites-available/000-default.conf
 COPY fusiondirectory.conf /fusiondirectory.conf
+COPY msmtp.conf /msmtp.conf
 COPY start.sh /start.sh
 
 ENTRYPOINT ["/start.sh"]

--- a/apache.conf
+++ b/apache.conf
@@ -16,6 +16,7 @@ MaxSpareServers 3
         php_admin_flag register_long_arrays off
         php_admin_value upload_tmp_dir /var/spool/fusiondirectory/
         php_admin_value session.cookie_lifetime 0
+        php_admin_value sendmail_path "/usr/bin/msmtp -t"
     # Remove the comment from the line below if you use fusiondirectory-setup --encrypt-passwords
     #   include /etc/fusiondirectory/fusiondirectory.secrets
     </Location>

--- a/msmtp.conf
+++ b/msmtp.conf
@@ -1,0 +1,22 @@
+# A system wide configuration.
+# This allows msmtp to be used like /usr/sbin/sendmail.
+account default
+
+# The SMTP smarthost.
+host $SMTP_HOST
+port $SMTP_PORT
+domain $SMTP_DOMAIN
+
+# Construct envelope-from addresses of the form "user@oursite.example".
+auto_from on
+maildomain $SMTP_MAILDOMAIN
+
+# Authentication.
+auth $SMTP_AUTHENTICATION
+user $SMTP_USER
+password $SMTP_PASS
+
+# TLS configuration.
+tls $SMTP_TLS
+tls_starttls $SMTP_STARTTLS
+tls_certcheck $SMTP_TLSCERTCHECK

--- a/start.sh
+++ b/start.sh
@@ -24,5 +24,9 @@ EOF
     touch /etc/ldap/fusionready
 fi
 
+if [ "$SMTP_ENABLED" = "true" ]; then
+    envsubst < /msmtp.conf > /etc/msmtprc
+fi
+
 . /etc/apache2/envvars
 /usr/sbin/apache2 -D FOREGROUND


### PR DESCRIPTION
Actually, this PR contains two things:
* Update FusionDirectory repository and version to 1.0.9.3, in order to have successful automated builds, as 1.0.9.1 packages are no longer served. Updating to even more recent versions could break existing schemas.
* To enable FusionDirectory password recovery, PHP and apache need a working SMTP configuration to send a link to the user email.
[msmtp](http://msmtp.sourceforge.net/) seems to be a very-easy-to-configure SMTP client also compatible with the postfix service in Shasoco.
Last, the variables currently used seem to be enough for our needs, there is no support of all [available msmtp configuration commands](http://msmtp.sourceforge.net/doc/msmtp.html#Configuration-files). Could be done but is it needed?

Cheers,
